### PR TITLE
Feature/normalize line endings in code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,1 @@
+end_of_line = lf

--- a/Assets/ScriptTemplates.meta
+++ b/Assets/ScriptTemplates.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cc959e401531f5b4da1b004a539209d9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptTemplates/81-C# Script-NewBehaviourScript.cs.txt
+++ b/Assets/ScriptTemplates/81-C# Script-NewBehaviourScript.cs.txt
@@ -1,0 +1,19 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace WitchOS
+{
+    public class #SCRIPTNAME# : MonoBehaviour
+    {
+        void Start()
+        {
+            #NOTRIM#
+        }
+
+        void Update()
+        {
+            #NOTRIM#
+        }
+    }
+}

--- a/Assets/ScriptTemplates/81-C# Script-NewBehaviourScript.cs.txt.meta
+++ b/Assets/ScriptTemplates/81-C# Script-NewBehaviourScript.cs.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c49cca811dc6eed4b8619e6ed7a944f1
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptTemplates/83-C# Script-NewTestScript.cs.txt
+++ b/Assets/ScriptTemplates/83-C# Script-NewTestScript.cs.txt
@@ -1,0 +1,13 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace WitchOS.Tests
+{
+    public class #SCRIPTNAME#
+    {
+        #NOTRIM#
+    }
+}

--- a/Assets/ScriptTemplates/83-C# Script-NewTestScript.cs.txt.meta
+++ b/Assets/ScriptTemplates/83-C# Script-NewTestScript.cs.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b56c8ed337f7109439c2dd9c2d04299a
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
https://crass-sandwich.atlassian.net/browse/WITCH-84?atlOrigin=eyJpIjoiNzAzYTgxNDc4MmRjNDQ1ZDg4NTVhYTg0MGU0NWRkM2IiLCJwIjoiaiJ9

Somehow there aren't any \r\n pairs in the entire project, which is suspicious. Makes me think that Visual Studio replaces those with your configured line ending on save, or the searches I did simply didn't catch any. In any case, these changes should be enough going forward, but I might need to revisit this if Unity complains again.